### PR TITLE
Improvements to nix architecture

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1768127708,
@@ -36,9 +18,9 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay",
+        "systems": "systems"
       }
     },
     "rust-overlay": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+    systems.url = "github:nix-systems/default";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -13,82 +13,38 @@
   outputs = {
     self,
     nixpkgs,
-    flake-utils,
+    systems,
     rust-overlay,
     ...
-  }:
-    flake-utils.lib.eachDefaultSystem (
-      system: let
-        overlays = [(import rust-overlay)];
-        pkgs = import nixpkgs {
-          inherit system overlays;
-        };
-
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
-          extensions = ["rust-src" "rust-analyzer" "clippy" "rustfmt"];
-        };
-
+  }: let
+    withOverlay = pkgs: pkgs.extend (import rust-overlay);
+    eachSystem = fn:
+      nixpkgs.lib.genAttrs
+      (import systems)
+      (system: fn (withOverlay nixpkgs.legacyPackages.${system}));
+  in {
+    packages = eachSystem (pkgs: let
+      rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+        extensions = [
+          "rust-src"
+          "rust-analyzer"
+          "clippy"
+          "rustfmt"
+        ];
+      };
+    in {
+      default = pkgs.callPackage ./nix/package.nix {
         rustPlatform = pkgs.makeRustPlatform {
           cargo = rustToolchain;
           rustc = rustToolchain;
         };
-      in {
-        packages.default = rustPlatform.buildRustPackage {
-          pname = "oxicord";
-          version = "0.1.7";
+      };
+    });
 
-          src = ./.;
-
-          cargoLock = {
-            lockFile = ./Cargo.lock;
-          };
-
-          nativeBuildInputs = [pkgs.pkg-config pkgs.clang pkgs.mold pkgs.makeBinaryWrapper];
-
-          buildInputs = [
-            pkgs.dbus
-            pkgs.chafa
-            pkgs.glib
-          ];
-
-          preCheck = ''
-            export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [pkgs.dbus.lib pkgs.chafa pkgs.glib]}:$LD_LIBRARY_PATH
-          '';
-
-          postInstall = ''
-            wrapProgram $out/bin/oxicord \
-              --prefix LD_LIBRARY_PATH : "${pkgs.lib.makeLibraryPath [pkgs.dbus.lib pkgs.chafa pkgs.glib]}"
-          '';
-
-          meta = with pkgs.lib; {
-            description = "A lightweight, secure Discord terminal client";
-            homepage = "https://github.com/linuxmobile/oxicord";
-            license = licenses.mit;
-            maintainers = [];
-            mainProgram = "oxicord";
-            platforms = platforms.unix;
-          };
-        };
-
-        devShells.default = pkgs.mkShell {
-          RUSTFLAGS = "-C link-arg=-fuse-ld=mold";
-          packages = [
-            rustToolchain
-            pkgs.cargo-watch
-            pkgs.pkg-config
-            pkgs.clang
-            pkgs.mold
-          ];
-
-          buildInputs = [
-            pkgs.dbus
-            pkgs.chafa
-            pkgs.glib
-          ];
-
-          PKG_CONFIG_PATH = "${pkgs.chafa}/lib/pkgconfig:${pkgs.glib.dev}/lib/pkgconfig:${pkgs.dbus.dev}/lib/pkgconfig";
-          LD_LIBRARY_PATH = "${pkgs.chafa}/lib:${pkgs.glib.out}/lib:${pkgs.dbus.lib}/lib";
-        };
-      }
-    );
+    devShells = eachSystem (pkgs: {
+      default = pkgs.callPackage ./nix/shell.nix {
+        oxicord = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+      };
+    });
+  };
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  clang,
+  makeBinaryWrapper,
+  mold,
+  dbus,
+  chafa,
+  glib,
+}:
+rustPlatform.buildRustPackage (final: let
+  inherit (lib.fileset) toSource unions;
+  inherit (lib) licenses platforms;
+in {
+  pname = "oxicord";
+  version = "0.1.7";
+
+  src = toSource {
+    root = ../.;
+    fileset = unions [
+      ../src
+      ../Cargo.lock
+      ../Cargo.toml
+    ];
+  };
+
+  cargoLock.lockFile = ../Cargo.lock;
+
+  nativeBuildInputs = [
+    pkg-config
+    clang
+    mold
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    dbus
+    chafa
+    glib
+  ];
+
+  meta = {
+    description = "A lightweight, secure Discord terminal client";
+    homepage = "https://github.com/linuxmobile/oxicord";
+    license = licenses.mit;
+    maintainers = [];
+    mainProgram = "oxicord";
+    platforms = platforms.unix;
+  };
+})

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,17 @@
+{
+  mkShell,
+  stdenvAdapters,
+  cargo-watch,
+  oxicord,
+}:
+mkShell.override (old: {
+  stdenv = stdenvAdapters.useMoldLinker old.stdenv;
+}) {
+  inputsFrom = [
+    oxicord
+  ];
+
+  packages = [
+    cargo-watch
+  ];
+}


### PR DESCRIPTION
copy pasting commit body here:

- Removal of flake-utils: https://ayats.org/blog/no-flake-utils
- expose nix-systems on flake (formerly an input of flake-utils): https://github.com/nix-systems/nix-systems
- introduced down stream overidability of package with `callPackage`: https://nixos.org/guides/nix-pills/13-callpackage-design-pattern
- pruned redundancies in devShell and package
- used stdenvAdapter for using mold linker in devShell
- modularized flake, composing in a flake independent manner (allows easy non flake usage)
- used filesets to prevent wasted rebuilds when non-source files change (readme, etc)

Happy to elaborate on any modification /