### PR TITLE
Fix: ignore key release events on Windows (fixes #11)

### DIFF
--- a/src/presentation/ui/app.rs
+++ b/src/presentation/ui/app.rs
@@ -312,20 +312,28 @@ impl App {
                 }
 
                 Some(Ok(event)) = terminal_event => {
-                    let result = self.handle_terminal_event(&event);
-                    match result {
-                        EventResult::Exit => {
-                            self.state = AppState::Exiting;
-                        }
-                        EventResult::OpenEditor {
-                            initial_content,
-                            message_id,
-                        } => {
-                            self.handle_open_editor(terminal, &initial_content, message_id)?;
-                            self.should_render = true;
-                        }
-                        _ => {
-                            self.should_render = true;
+                    let is_release_event = matches!(
+                        event, 
+                        crossterm::event::Event::Key(key) 
+                        if key.kind == crossterm::event::KeyEventKind::Release
+                    );
+
+                    if !is_release_event {
+                        let result = self.handle_terminal_event(&event);
+                        match result {
+                            EventResult::Exit => {
+                                self.state = AppState::Exiting;
+                            }
+                            EventResult::OpenEditor {
+                                initial_content,
+                                message_id,
+                            } => {
+                                self.handle_open_editor(terminal, &initial_content, message_id)?;
+                                self.should_render = true;
+                            }
+                            _ => {
+                                self.should_render = true;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #11, where Windows users experience double input due to the terminal emitting both a press and a release event for a single key action. On the previous code, the application processes both events as presses, leading to duplicate inputs. The updated code filters out key release events. This does not break typing, or holding down keys. I tested this to be working on Windows. Although it should not break input on other platforms, I could not test those at the time.