### PR TITLE
feat: Image on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ bytes = "1.11.1"
 ratatui-image = { version = "10.0.3", features = ["crossterm", "chafa-dyn"], default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-ratatui-image = { version = "10.0.3", features = ["crossterm"], default-features = false }
+ratatui-image = { version = "10.0.3", features = ["crossterm", "chafa-dyn"], default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 ratatui-image = { version = "10.0.3", features = ["crossterm"], default-features = false }


### PR DESCRIPTION
This PR enables Image rendering on macOS by...... simply enabling `chafa-dyn` feature on macOS

With Nix this is really easy, and like previous builds just get libchafa with `brew install chafa`