### PR TITLE
feat: Generic URL decoding in markdown parser and renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,6 +2168,7 @@ dependencies = [
  "notify-rust",
  "opener",
  "parking_lot",
+ "percent-encoding",
  "ratatui 0.30.0",
  "ratatui-image",
  "regex",
@@ -2190,6 +2191,7 @@ dependencies = [
  "tui-scrollbar",
  "tui-textarea",
  "unicode-width 0.2.0",
+ "url",
  "uuid",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,8 @@ coolor = "1.1.0"
 fuzzy-matcher = "0.3.7"
 termbg = "0.6.2"
 bytes = "1.11.1"
+url = "2.5"
+percent-encoding = "2.3"
 
 # Image rendering - Platform Specific
 

--- a/src/application/services/markdown_parser.rs
+++ b/src/application/services/markdown_parser.rs
@@ -37,6 +37,7 @@ pub enum MdInline {
     Code(String),
     Mention(String),
     Channel(String),
+    Url(String),
 }
 
 #[must_use]
@@ -228,7 +229,7 @@ fn handle_special_chars(
             true
         }
         'h' => {
-            handle_discord_url(input, idx, start, inlines, chars);
+            handle_url(input, idx, start, inlines, chars);
             true
         }
         '\\' => {
@@ -274,7 +275,7 @@ fn handle_inline_code(
     }
 }
 
-fn handle_discord_url(
+fn handle_url(
     input: &str,
     idx: usize,
     start: &mut usize,
@@ -282,6 +283,8 @@ fn handle_discord_url(
     chars: &mut Peekable<CharIndices>,
 ) {
     let remaining = &input[idx..];
+
+    // Check for Discord Channel URLs first
     if remaining.starts_with("https://discord.com/channels/")
         || remaining.starts_with("https://ptb.discord.com/channels/")
         || remaining.starts_with("https://canary.discord.com/channels/")
@@ -311,8 +314,33 @@ fn handle_discord_url(
                     }
                 }
                 *start = end_pos;
+                return;
             }
         }
+    }
+
+    // Generic URL handling
+    if remaining.starts_with("http://") || remaining.starts_with("https://") {
+        let url_end_offset = remaining
+            .find(|c: char| c.is_whitespace() || c == ')')
+            .unwrap_or(remaining.len());
+        let url_str = &remaining[..url_end_offset];
+
+        if idx > *start {
+            inlines.push(MdInline::Text(input[*start..idx].to_string()));
+        }
+
+        inlines.push(MdInline::Url(url_str.to_string()));
+
+        let end_pos = idx + url_end_offset;
+        while let Some((curr, _)) = chars.peek() {
+            if *curr < end_pos {
+                chars.next();
+            } else {
+                break;
+            }
+        }
+        *start = end_pos;
     }
 }
 
@@ -562,6 +590,37 @@ mod tests {
                 assert_eq!(id, "456");
             } else {
                 panic!("Expected Channel inline");
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_generic_url() {
+        let content = "Check https://example.com/foo";
+        let blocks = parse_markdown(content);
+        if let MdBlock::Paragraph(inlines) = &blocks[0] {
+            assert_eq!(inlines.len(), 2);
+            if let MdInline::Text(t) = &inlines[0] {
+                assert_eq!(t, "Check ");
+            }
+            if let MdInline::Url(url) = &inlines[1] {
+                assert_eq!(url, "https://example.com/foo");
+            } else {
+                panic!("Expected Url inline");
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_generic_url_in_text() {
+        let content = "Link https://google.com here";
+        let blocks = parse_markdown(content);
+        if let MdBlock::Paragraph(inlines) = &blocks[0] {
+            assert_eq!(inlines.len(), 3);
+            if let MdInline::Url(url) = &inlines[1] {
+                assert_eq!(url, "https://google.com");
+            } else {
+                panic!("Expected Url inline");
             }
         }
     }

--- a/src/presentation/services/markdown_renderer.rs
+++ b/src/presentation/services/markdown_renderer.rs
@@ -1,6 +1,8 @@
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use std::sync::Arc;
+use url::Url;
+use percent_encoding::percent_decode_str;
 
 use super::syntax_highlighting::{SyntaxHighlighter, SyntectHighlighter};
 use crate::application::services::markdown_parser::{MdBlock, MdInline, MentionResolver};
@@ -231,6 +233,32 @@ impl<'a> InternalRenderer<'a> {
                         style.fg(Color::Blue).add_modifier(Modifier::BOLD),
                     ));
                 }
+                MdInline::Url(url_str) => {
+                    let display_text = if let Ok(parsed) = Url::parse(&url_str) {
+                         let scheme = parsed.scheme();
+                         let host = parsed.host_str().unwrap_or("");
+                         let path = percent_decode_str(parsed.path()).decode_utf8_lossy();
+                         let query = if let Some(q) = parsed.query() {
+                             format!("?{}", percent_decode_str(q).decode_utf8_lossy())
+                         } else {
+                             String::new()
+                         };
+                         let fragment = if let Some(f) = parsed.fragment() {
+                             format!("#{}", percent_decode_str(f).decode_utf8_lossy())
+                         } else {
+                             String::new()
+                         };
+
+                         format!("{}://{}{}{}{}", scheme, host, path, query, fragment)
+                    } else {
+                        url_str.clone()
+                    };
+
+                    spans.push(Span::styled(
+                        display_text,
+                        style.fg(Color::Blue).add_modifier(Modifier::UNDERLINED),
+                    ));
+                }
             }
         }
         spans
@@ -268,5 +296,26 @@ mod tests {
 
         assert_eq!(span.style.bg, Some(Color::Rgb(50, 50, 50)));
         assert_ne!(span.style.fg, Some(Color::Rgb(50, 50, 50)));
+    }
+
+    #[test]
+    fn test_render_decoded_url() {
+        let content = "https://example.com/%E6%B5%8B%E8%AF%95";
+        let blocks = parse_markdown(content);
+        let renderer = MarkdownRenderer::new();
+        let text = renderer.render(blocks, None, false);
+
+        let line = &text.lines[0];
+        // The parser might produce [Url] or [Text, Url], but since the whole string is the URL:
+        // parse_markdown("https://...") should return [Paragraph([Url("https://...")])]
+
+        let spans = &line.spans;
+        // Depending on parser implementation, it might just find the URL.
+
+        // Find the span that corresponds to URL.
+        let url_span = spans.iter().find(|s| s.content.starts_with("https://example.com/")).unwrap();
+
+        // "测试" is the decoded characters for %E6%B5%8B%E8%AF%95
+        assert_eq!(url_span.content, "https://example.com/测试");
     }
 }


### PR DESCRIPTION
Implemented generic URL decoding to improve readability for encoded paths (e.g., CJK characters). 
The solution decodes the path, query, and fragment components for display purposes while keeping the host intact to prevent homograph attacks. 
Standard HTTP/HTTPS URLs are now parsed as `MdInline::Url` and rendered with decoded components.