### PR TITLE
fix(app): potential command injection in EDITOR configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tracing = { version = "0.1.44", default-features = false, features = ["std", "at
 tracing-subscriber = { version = "0.3.22", default-features = false, features = ["env-filter", "fmt", "ansi", "std", "registry"] }
 
 async-trait = "0.1.89"
+shlex = "1.3"
 
 dotenvy = "0.15.7"
 


### PR DESCRIPTION
- Replace custom `split_command` with `shlex::split` to prevent command injection and parsing issues.
- Update `src/presentation/ui/app.rs` to handle parsing failures gracefully.
- Add `shlex` dependency.
- This change ensures that user-provided `EDITOR` strings are parsed safely according to POSIX shell rules, preventing argument injection vulnerabilities.