### PR TITLE
chore: refactor wrap_text to fix unsafe unwrap

### DIFF
--- a/src/presentation/widgets/message_pane.rs
+++ b/src/presentation/widgets/message_pane.rs
@@ -2624,7 +2624,8 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
                     let mut split_width = 0;
 
                     for (idx, c) in remaining_word.char_indices() {
-                        let w = UnicodeWidthStr::width(c.to_string().as_str());
+                        let mut buf = [0u8; 4];
+                        let w = UnicodeWidthStr::width(c.encode_utf8(&mut buf));
                         if split_width + w > width {
                             split_idx = idx;
                             break;
@@ -2632,9 +2633,10 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
                         split_width += w;
                     }
 
-                    if split_idx == 0 && !remaining_word.is_empty() {
-                        let (idx, c) = remaining_word.char_indices().next().unwrap();
-                        split_idx = idx + c.len_utf8();
+                    if split_idx == 0 {
+                        if let Some((idx, c)) = remaining_word.char_indices().next() {
+                            split_idx = idx + c.len_utf8();
+                        }
                     }
 
                     lines.push(remaining_word[..split_idx].to_string());
@@ -2712,6 +2714,12 @@ fn wrap_styled_text(text: Text<'static>, width: u16) -> Text<'static> {
                                 }
                                 split_w += cw;
                                 split_idx = idx + c.len_utf8();
+                            }
+
+                            if split_idx == 0 {
+                                if let Some((idx, c)) = remaining_word.char_indices().next() {
+                                    split_idx = idx + c.len_utf8();
+                                }
                             }
 
                             if split_idx > 0 {


### PR DESCRIPTION
- Replaced unsafe `.unwrap()` in `wrap_text` with safe `if let Some` pattern.
- Optimized character width calculation in `wrap_text` by using `encode_utf8` with a local buffer to avoid heap allocations from `to_string()`.
- Added a safety check in `wrap_styled_text` to prevent a potential infinite loop when a character width exceeds the available space.
- Verified wrapping logic for various edge cases (narrow widths, multi-width characters) using a standalone verification script.