### PR TITLE
refactor(token): centralize placeholder token for tests

### DIFF
--- a/src/application/use_cases/login_use_case.rs
+++ b/src/application/use_cases/login_use_case.rs
@@ -96,11 +96,8 @@ impl LoginUseCase {
 mod tests {
     use super::*;
     use crate::application::dto::TokenSource;
+    use crate::domain::entities::AuthToken;
     use crate::domain::ports::mocks::{MockAuthPort, MockTokenStorage};
-
-    fn make_valid_token() -> String {
-        "MTIzNDU2Nzg5MDEyMzQ1Njc4OQ.XXXXXX.YYYYYYYYYYYYYYYYYYYYYYYYYYYY".to_string()
-    }
 
     #[tokio::test]
     async fn test_successful_login() {
@@ -108,7 +105,7 @@ mod tests {
         let storage_port = Arc::new(MockTokenStorage::new());
 
         let use_case = LoginUseCase::new(auth_port, storage_port.clone());
-        let request = LoginRequest::new(make_valid_token(), TokenSource::Environment);
+        let request = LoginRequest::new(AuthToken::dummy(), TokenSource::Environment);
 
         let result = use_case.execute(request).await;
 
@@ -139,7 +136,7 @@ mod tests {
         let storage_port = Arc::new(MockTokenStorage::new());
 
         let use_case = LoginUseCase::new(auth_port, storage_port);
-        let request = LoginRequest::new(make_valid_token(), TokenSource::UserInput);
+        let request = LoginRequest::new(AuthToken::dummy(), TokenSource::UserInput);
 
         let result = use_case.execute(request).await;
 
@@ -153,7 +150,7 @@ mod tests {
 
         let use_case = LoginUseCase::new(auth_port, storage_port.clone());
         let request =
-            LoginRequest::new(make_valid_token(), TokenSource::Environment).without_persistence();
+            LoginRequest::new(AuthToken::dummy(), TokenSource::Environment).without_persistence();
 
         let result = use_case.execute(request).await;
 

--- a/src/application/use_cases/resolve_token_use_case.rs
+++ b/src/application/use_cases/resolve_token_use_case.rs
@@ -87,18 +87,14 @@ mod tests {
     use super::*;
     use crate::domain::ports::mocks::MockTokenStorage;
 
-    fn make_valid_token() -> String {
-        "MTIzNDU2Nzg5MDEyMzQ1Njc4OQ.XXXXXX.YYYYYYYYYYYYYYYYYYYYYYYYYYYY".to_string()
-    }
-
     #[tokio::test]
     async fn test_external_token_priority() {
         let storage = Arc::new(MockTokenStorage::with_token(AuthToken::new_unchecked(
-            make_valid_token(),
+            AuthToken::dummy(),
         )));
         let use_case = ResolveTokenUseCase::new(storage);
 
-        let env_token = make_valid_token();
+        let env_token = AuthToken::dummy();
         let result = use_case
             .execute(Some((env_token, TokenSource::Environment)))
             .await
@@ -111,7 +107,7 @@ mod tests {
     #[tokio::test]
     async fn test_keyring_fallback() {
         let storage = Arc::new(MockTokenStorage::with_token(AuthToken::new_unchecked(
-            make_valid_token(),
+            AuthToken::dummy(),
         )));
         let use_case = ResolveTokenUseCase::new(storage);
 

--- a/src/domain/entities/token.rs
+++ b/src/domain/entities/token.rs
@@ -52,6 +52,13 @@ impl AuthToken {
         self.value.clone()
     }
 
+    /// Returns dummy token for testing.
+    #[cfg(test)]
+    #[must_use]
+    pub fn dummy() -> String {
+        "MTIzNDU2Nzg5MDEyMzQ1Njc4OQ.XXXXXX.YYYYYYYYYYYYYYYYYYYYYYYYYYYY".to_string()
+    }
+
     /// Returns masked token for display.
     #[must_use]
     pub fn masked(&self) -> String {
@@ -83,13 +90,9 @@ impl fmt::Display for AuthToken {
 mod tests {
     use super::*;
 
-    fn make_valid_token() -> String {
-        "MTIzNDU2Nzg5MDEyMzQ1Njc4OQ.XXXXXX.YYYYYYYYYYYYYYYYYYYYYYYYYYYY".to_string()
-    }
-
     #[test]
     fn test_valid_token_creation() {
-        let token = AuthToken::new(make_valid_token());
+        let token = AuthToken::new(AuthToken::dummy());
         assert!(token.is_some());
     }
 
@@ -107,18 +110,20 @@ mod tests {
 
     #[test]
     fn test_token_masking() {
-        let token = AuthToken::new_unchecked(make_valid_token());
+        let dummy = AuthToken::dummy();
+        let token = AuthToken::new_unchecked(AuthToken::dummy());
         let masked = token.masked();
 
         assert!(masked.contains("..."));
-        assert!(!masked.contains(&make_valid_token()));
+        assert!(!masked.contains(&dummy));
     }
 
     #[test]
     fn test_debug_does_not_leak_token() {
-        let token = AuthToken::new_unchecked(make_valid_token());
+        let dummy = AuthToken::dummy();
+        let token = AuthToken::new_unchecked(AuthToken::dummy());
         let debug_output = format!("{token:?}");
 
-        assert!(!debug_output.contains(&make_valid_token()));
+        assert!(!debug_output.contains(&dummy));
     }
 }

--- a/src/infrastructure/storage/keyring_storage.rs
+++ b/src/infrastructure/storage/keyring_storage.rs
@@ -141,9 +141,7 @@ mod tests {
     #[ignore = "requires system keyring"]
     async fn test_store_and_retrieve_token() {
         let storage = KeyringTokenStorage::with_names("oxicord-test", "test-token");
-        let token = AuthToken::new_unchecked(
-            "MTIzNDU2Nzg5MDEyMzQ1Njc4OQ.XXXXXX.YYYYYYYYYYYYYYYYYYYYYYYYYYYY",
-        );
+        let token = AuthToken::new_unchecked(AuthToken::dummy());
 
         storage.store_token(&token).await.unwrap();
 


### PR DESCRIPTION
- Added `#[cfg(test)] AuthToken::dummy()` to provide a valid-format mock token.
- Updated `token.rs`, `login_use_case.rs`, `resolve_token_use_case.rs`, and `keyring_storage.rs` tests to use the new helper.
- Removed duplicated local `make_valid_token()` helpers in test modules.
- Fixed missing `AuthToken` imports in test scopes.