### PR TITLE
feat: configurable selection and base text colors

### DIFF
--- a/src/infrastructure/config/app_config.rs
+++ b/src/infrastructure/config/app_config.rs
@@ -221,6 +221,10 @@ pub struct ThemeConfig {
     #[serde(default)]
     pub selection_color: Option<String>,
 
+    /// Base text color (name or hex code).
+    #[serde(default)]
+    pub base_color: Option<String>,
+
     /// Theme mode (Dark, Light, Auto).
     #[serde(default)]
     pub mode: ThemeMode,
@@ -248,6 +252,7 @@ impl Default for ThemeConfig {
             accent_color: default_accent_color(),
             mention_color: None,
             selection_color: None,
+            base_color: None,
             mode: ThemeMode::default(),
         }
     }
@@ -290,6 +295,9 @@ impl AppConfig {
         }
         if let Some(selection_color) = args.selection_color {
             self.theme.selection_color = Some(selection_color);
+        }
+        if let Some(base_color) = args.base_color {
+            self.theme.base_color = Some(base_color);
         }
         if let Some(show_typing) = args.show_typing {
             self.ui.show_typing = show_typing;

--- a/src/infrastructure/config/app_config.rs
+++ b/src/infrastructure/config/app_config.rs
@@ -225,6 +225,10 @@ pub struct ThemeConfig {
     #[serde(default)]
     pub base_color: Option<String>,
 
+    /// Text color inside accented headers/blocks (name or hex code).
+    #[serde(default)]
+    pub header_text_color: Option<String>,
+
     /// Theme mode (Dark, Light, Auto).
     #[serde(default)]
     pub mode: ThemeMode,
@@ -253,6 +257,7 @@ impl Default for ThemeConfig {
             mention_color: None,
             selection_color: None,
             base_color: None,
+            header_text_color: None,
             mode: ThemeMode::default(),
         }
     }
@@ -298,6 +303,9 @@ impl AppConfig {
         }
         if let Some(base_color) = args.base_color {
             self.theme.base_color = Some(base_color);
+        }
+        if let Some(header_text_color) = args.header_text_color {
+            self.theme.header_text_color = Some(header_text_color);
         }
         if let Some(show_typing) = args.show_typing {
             self.ui.show_typing = show_typing;

--- a/src/infrastructure/config/app_config.rs
+++ b/src/infrastructure/config/app_config.rs
@@ -217,6 +217,10 @@ pub struct ThemeConfig {
     #[serde(default)]
     pub mention_color: Option<String>,
 
+    /// Selection background color (name or hex code).
+    #[serde(default)]
+    pub selection_color: Option<String>,
+
     /// Theme mode (Dark, Light, Auto).
     #[serde(default)]
     pub mode: ThemeMode,
@@ -243,6 +247,7 @@ impl Default for ThemeConfig {
         Self {
             accent_color: default_accent_color(),
             mention_color: None,
+            selection_color: None,
             mode: ThemeMode::default(),
         }
     }
@@ -282,6 +287,9 @@ impl AppConfig {
         }
         if let Some(accent_color) = args.accent_color {
             self.theme.accent_color = accent_color;
+        }
+        if let Some(selection_color) = args.selection_color {
+            self.theme.selection_color = Some(selection_color);
         }
         if let Some(show_typing) = args.show_typing {
             self.ui.show_typing = show_typing;

--- a/src/infrastructure/config/args.rs
+++ b/src/infrastructure/config/args.rs
@@ -65,4 +65,8 @@ pub struct CliArgs {
     /// Selection background color (name or hex code).
     #[arg(long)]
     pub selection_color: Option<String>,
+
+    /// Base text color (name or hex code).
+    #[arg(long)]
+    pub base_color: Option<String>,
 }

--- a/src/infrastructure/config/args.rs
+++ b/src/infrastructure/config/args.rs
@@ -61,4 +61,8 @@ pub struct CliArgs {
     /// Accent color (name or hex code).
     #[arg(long)]
     pub accent_color: Option<String>,
+
+    /// Selection background color (name or hex code).
+    #[arg(long)]
+    pub selection_color: Option<String>,
 }

--- a/src/infrastructure/config/args.rs
+++ b/src/infrastructure/config/args.rs
@@ -69,4 +69,8 @@ pub struct CliArgs {
     /// Base text color (name or hex code).
     #[arg(long)]
     pub base_color: Option<String>,
+
+    /// Text color inside accented headers/blocks (name or hex code).
+    #[arg(long)]
+    pub header_text_color: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,7 @@ fn create_app() -> Result<(App, Option<(String, TokenSource)>)> {
         &config.theme.accent_color,
         config.theme.mention_color.as_deref(),
         config.theme.selection_color.as_deref(),
+        config.theme.base_color.as_deref(),
         is_light_mode,
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,7 @@ fn create_app() -> Result<(App, Option<(String, TokenSource)>)> {
     let theme = Theme::new(
         &config.theme.accent_color,
         config.theme.mention_color.as_deref(),
+        config.theme.selection_color.as_deref(),
         is_light_mode,
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ fn create_app() -> Result<(App, Option<(String, TokenSource)>)> {
         config.theme.mention_color.as_deref(),
         config.theme.selection_color.as_deref(),
         config.theme.base_color.as_deref(),
+        config.theme.header_text_color.as_deref(),
         is_light_mode,
     );
 

--- a/src/presentation/services/markdown_renderer.rs
+++ b/src/presentation/services/markdown_renderer.rs
@@ -30,9 +30,10 @@ impl MarkdownRenderer {
         blocks: Vec<MdBlock>,
         resolver: Option<&dyn MentionResolver>,
         show_spoilers: bool,
+        parent_style: Style,
     ) -> Text<'static> {
         let mut renderer = InternalRenderer::new(resolver, &self.highlighter, show_spoilers);
-        renderer.render(blocks)
+        renderer.render(blocks, parent_style)
     }
 
     #[must_use]
@@ -41,9 +42,10 @@ impl MarkdownRenderer {
         content: &str,
         resolver: Option<&dyn MentionResolver>,
         show_spoilers: bool,
+        parent_style: Style,
     ) -> Text<'static> {
         let blocks = crate::application::services::markdown_parser::parse_markdown(content);
-        self.render(blocks, resolver, show_spoilers)
+        self.render(blocks, resolver, show_spoilers, parent_style)
     }
 }
 
@@ -72,10 +74,10 @@ impl<'a> InternalRenderer<'a> {
         }
     }
 
-    fn render(&mut self, blocks: Vec<MdBlock>) -> Text<'static> {
+    fn render(&mut self, blocks: Vec<MdBlock>, parent_style: Style) -> Text<'static> {
         let mut lines = Vec::new();
         for block in blocks {
-            self.render_block(block, &mut lines, Style::default());
+            self.render_block(block, &mut lines, parent_style);
         }
         Text::from(lines)
     }

--- a/src/presentation/theme/palette.rs
+++ b/src/presentation/theme/palette.rs
@@ -15,7 +15,7 @@ pub trait Palette {
     fn timestamp_style(&self) -> Style;
     fn keybind_style(&self, base: Color) -> Style;
     fn keybind_description_style(&self, override_color: Option<Color>) -> Style;
-    fn title_style(&self, base: Color) -> Style;
+    fn title_style(&self, base: Color, override_color: Option<Color>) -> Style;
     fn tab_style(&self) -> Style;
     fn tab_selected_style(&self) -> Style;
     fn statusbar_style(&self) -> Style;
@@ -83,10 +83,10 @@ impl Palette for DarkPalette {
         self.base_style(override_color)
     }
 
-    fn title_style(&self, base: Color) -> Style {
+    fn title_style(&self, base: Color, override_color: Option<Color>) -> Style {
         Style::default()
             .bg(base)
-            .fg(Color::Black)
+            .fg(override_color.unwrap_or(Color::Black))
             .add_modifier(Modifier::BOLD)
     }
 
@@ -170,10 +170,10 @@ impl Palette for LightPalette {
         self.base_style(override_color)
     }
 
-    fn title_style(&self, base: Color) -> Style {
+    fn title_style(&self, base: Color, override_color: Option<Color>) -> Style {
         Style::default()
             .bg(base)
-            .fg(Color::Black)
+            .fg(override_color.unwrap_or(Color::Black))
             .add_modifier(Modifier::BOLD)
     }
 

--- a/src/presentation/theme/palette.rs
+++ b/src/presentation/theme/palette.rs
@@ -4,7 +4,7 @@ use ratatui::style::{Color, Modifier, Style};
 pub trait Palette {
     fn accent(&self, base: Color) -> Color;
     fn mention_style(&self, base: Color) -> Style;
-    fn selection_style(&self, base: Color) -> Style;
+    fn selection_style(&self, base: Color, override_color: Option<Color>) -> Style;
     fn dimmed_style(&self) -> Style;
     fn base_style(&self) -> Style;
     fn error_style(&self) -> Style;
@@ -35,18 +35,22 @@ impl Palette for DarkPalette {
         let bg = ColorConverter::to_ratatui(bg_hsl);
         Style::default().bg(bg).fg(Color::White)
     }
-    fn selection_style(&self, base: Color) -> Style {
-        let mut bg_hsl = ColorConverter::to_hsl(base);
-        bg_hsl.l = 0.2;
-        bg_hsl.s = 0.3;
-        let bg = ColorConverter::to_ratatui(bg_hsl);
+    fn selection_style(&self, base: Color, override_color: Option<Color>) -> Style {
+        let bg = if let Some(c) = override_color {
+            c
+        } else {
+            let mut bg_hsl = ColorConverter::to_hsl(base);
+            bg_hsl.l = 0.2;
+            bg_hsl.s = 0.3;
+            ColorConverter::to_ratatui(bg_hsl)
+        };
         Style::default().bg(bg).fg(Color::White)
     }
     fn dimmed_style(&self) -> Style {
         Style::default().fg(Color::DarkGray)
     }
     fn base_style(&self) -> Style {
-        Style::default().fg(Color::Reset)
+        Style::default().fg(Color::White)
     }
     fn error_style(&self) -> Style {
         Style::default().fg(Color::Red)
@@ -118,18 +122,22 @@ impl Palette for LightPalette {
         let bg = ColorConverter::to_ratatui(bg_hsl);
         Style::default().bg(bg).fg(Color::White)
     }
-    fn selection_style(&self, base: Color) -> Style {
-        let mut bg_hsl = ColorConverter::to_hsl(base);
-        bg_hsl.l = 0.8;
-        bg_hsl.s = 0.5;
-        let bg = ColorConverter::to_ratatui(bg_hsl);
+    fn selection_style(&self, base: Color, override_color: Option<Color>) -> Style {
+        let bg = if let Some(c) = override_color {
+            c
+        } else {
+            let mut bg_hsl = ColorConverter::to_hsl(base);
+            bg_hsl.l = 0.8;
+            bg_hsl.s = 0.5;
+            ColorConverter::to_ratatui(bg_hsl)
+        };
         Style::default().bg(bg).fg(Color::White)
     }
     fn dimmed_style(&self) -> Style {
         Style::default().fg(Color::DarkGray)
     }
     fn base_style(&self) -> Style {
-        Style::default().fg(Color::White)
+        Style::default().fg(Color::Black)
     }
     fn error_style(&self) -> Style {
         Style::default().bg(Color::Red).fg(Color::White)

--- a/src/presentation/theme/palette.rs
+++ b/src/presentation/theme/palette.rs
@@ -6,7 +6,7 @@ pub trait Palette {
     fn mention_style(&self, base: Color) -> Style;
     fn selection_style(&self, base: Color, override_color: Option<Color>) -> Style;
     fn dimmed_style(&self) -> Style;
-    fn base_style(&self) -> Style;
+    fn base_style(&self, override_color: Option<Color>) -> Style;
     fn error_style(&self) -> Style;
     fn warning_style(&self) -> Style;
     fn success_style(&self) -> Style;
@@ -14,7 +14,7 @@ pub trait Palette {
     fn border_style(&self) -> Style;
     fn timestamp_style(&self) -> Style;
     fn keybind_style(&self, base: Color) -> Style;
-    fn keybind_description_style(&self) -> Style;
+    fn keybind_description_style(&self, override_color: Option<Color>) -> Style;
     fn title_style(&self, base: Color) -> Style;
     fn tab_style(&self) -> Style;
     fn tab_selected_style(&self) -> Style;
@@ -49,8 +49,8 @@ impl Palette for DarkPalette {
     fn dimmed_style(&self) -> Style {
         Style::default().fg(Color::DarkGray)
     }
-    fn base_style(&self) -> Style {
-        Style::default().fg(Color::White)
+    fn base_style(&self, override_color: Option<Color>) -> Style {
+        Style::default().fg(override_color.unwrap_or(Color::Reset))
     }
     fn error_style(&self) -> Style {
         Style::default().fg(Color::Red)
@@ -79,8 +79,8 @@ impl Palette for DarkPalette {
         Style::default().bg(bg).fg(Color::White)
     }
 
-    fn keybind_description_style(&self) -> Style {
-        self.base_style()
+    fn keybind_description_style(&self, override_color: Option<Color>) -> Style {
+        self.base_style(override_color)
     }
 
     fn title_style(&self, base: Color) -> Style {
@@ -136,8 +136,8 @@ impl Palette for LightPalette {
     fn dimmed_style(&self) -> Style {
         Style::default().fg(Color::DarkGray)
     }
-    fn base_style(&self) -> Style {
-        Style::default().fg(Color::Black)
+    fn base_style(&self, override_color: Option<Color>) -> Style {
+        Style::default().fg(override_color.unwrap_or(Color::White))
     }
     fn error_style(&self) -> Style {
         Style::default().bg(Color::Red).fg(Color::White)
@@ -166,8 +166,8 @@ impl Palette for LightPalette {
         Style::default().bg(bg).fg(Color::Black)
     }
 
-    fn keybind_description_style(&self) -> Style {
-        self.base_style()
+    fn keybind_description_style(&self, override_color: Option<Color>) -> Style {
+        self.base_style(override_color)
     }
 
     fn title_style(&self, base: Color) -> Style {

--- a/src/presentation/theme/service.rs
+++ b/src/presentation/theme/service.rs
@@ -87,8 +87,13 @@ impl Theme {
 }
 
 fn parse_color(s: &str) -> Color {
-    if let Ok(c) = Color::from_str(s) {
+    let s_lower = s.to_lowercase();
+    if let Ok(c) = Color::from_str(&s_lower) {
         return c;
+    }
+
+    if s_lower == "transparent" {
+        return Color::Reset;
     }
 
     if s.starts_with('#')
@@ -97,7 +102,7 @@ fn parse_color(s: &str) -> Color {
         return Color::Rgb(r, g, b);
     }
 
-    match s.to_lowercase().as_str() {
+    match s_lower.as_str() {
         "orange" => Color::Indexed(208),
         _ => Color::Yellow,
     }

--- a/src/presentation/theme/service.rs
+++ b/src/presentation/theme/service.rs
@@ -25,7 +25,7 @@ pub struct Theme {
 
 impl Default for Theme {
     fn default() -> Self {
-        Self::new("Yellow", None, None, None, false)
+        Self::new("Yellow", None, None, None, None, false)
     }
 }
 
@@ -35,17 +35,19 @@ impl Theme {
         mention_color_str: Option<&str>,
         selection_color_str: Option<&str>,
         base_color_str: Option<&str>,
+        header_text_color_str: Option<&str>,
         is_light_mode: bool,
     ) -> Self {
         let accent = parse_color(accent_color_str);
         let mention = mention_color_str.map(parse_color);
         let selection = selection_color_str.map(parse_color);
         let base = base_color_str.map(parse_color);
+        let header = header_text_color_str.map(parse_color);
 
         if is_light_mode {
-            Self::from_palette(&LightPalette, accent, mention, selection, base)
+            Self::from_palette(&LightPalette, accent, mention, selection, base, header)
         } else {
-            Self::from_palette(&DarkPalette, accent, mention, selection, base)
+            Self::from_palette(&DarkPalette, accent, mention, selection, base, header)
         }
     }
 
@@ -55,13 +57,14 @@ impl Theme {
         mention_color: Option<Color>,
         selection_color: Option<Color>,
         base_color: Option<Color>,
+        header_text_color: Option<Color>,
     ) -> Self {
         let mention_base = mention_color.unwrap_or(Color::Blue);
 
         Self {
             keybind_style: palette.keybind_style(accent),
             keybind_description_style: palette.keybind_description_style(base_color),
-            title_style: palette.title_style(accent),
+            title_style: palette.title_style(accent, header_text_color),
             tab_style: palette.tab_style(),
             tab_selected_style: palette.tab_selected_style(),
             statusbar_style: palette.statusbar_style(),
@@ -85,8 +88,16 @@ impl Theme {
         mention_color: Option<Color>,
         selection_color: Option<Color>,
         base_color: Option<Color>,
+        header_text_color: Option<Color>,
     ) -> Self {
-        Self::from_palette(&DarkPalette, accent, mention_color, selection_color, base_color)
+        Self::from_palette(
+            &DarkPalette,
+            accent,
+            mention_color,
+            selection_color,
+            base_color,
+            header_text_color,
+        )
     }
 }
 

--- a/src/presentation/theme/service.rs
+++ b/src/presentation/theme/service.rs
@@ -25,7 +25,7 @@ pub struct Theme {
 
 impl Default for Theme {
     fn default() -> Self {
-        Self::new("Yellow", None, false)
+        Self::new("Yellow", None, None, false)
     }
 }
 
@@ -33,15 +33,17 @@ impl Theme {
     pub fn new(
         accent_color_str: &str,
         mention_color_str: Option<&str>,
+        selection_color_str: Option<&str>,
         is_light_mode: bool,
     ) -> Self {
         let accent = parse_color(accent_color_str);
         let mention = mention_color_str.map(parse_color);
+        let selection = selection_color_str.map(parse_color);
 
         if is_light_mode {
-            Self::from_palette(&LightPalette, accent, mention)
+            Self::from_palette(&LightPalette, accent, mention, selection)
         } else {
-            Self::from_palette(&DarkPalette, accent, mention)
+            Self::from_palette(&DarkPalette, accent, mention, selection)
         }
     }
 
@@ -49,6 +51,7 @@ impl Theme {
         palette: &P,
         accent: Color,
         mention_color: Option<Color>,
+        selection_color: Option<Color>,
     ) -> Self {
         let mention_base = mention_color.unwrap_or(Color::Blue);
 
@@ -61,7 +64,7 @@ impl Theme {
             statusbar_style: palette.statusbar_style(),
             accent: palette.accent(accent),
             mention_style: palette.mention_style(mention_base),
-            selection_style: palette.selection_style(accent),
+            selection_style: palette.selection_style(accent, selection_color),
             dimmed_style: palette.dimmed_style(),
             base_style: palette.base_style(),
             error_style: palette.error_style(),
@@ -74,8 +77,12 @@ impl Theme {
     }
 
     #[must_use]
-    pub fn from_color(accent: Color, mention_color: Option<Color>) -> Self {
-        Self::from_palette(&DarkPalette, accent, mention_color)
+    pub fn from_color(
+        accent: Color,
+        mention_color: Option<Color>,
+        selection_color: Option<Color>,
+    ) -> Self {
+        Self::from_palette(&DarkPalette, accent, mention_color, selection_color)
     }
 }
 

--- a/src/presentation/theme/service.rs
+++ b/src/presentation/theme/service.rs
@@ -25,7 +25,7 @@ pub struct Theme {
 
 impl Default for Theme {
     fn default() -> Self {
-        Self::new("Yellow", None, None, false)
+        Self::new("Yellow", None, None, None, false)
     }
 }
 
@@ -34,16 +34,18 @@ impl Theme {
         accent_color_str: &str,
         mention_color_str: Option<&str>,
         selection_color_str: Option<&str>,
+        base_color_str: Option<&str>,
         is_light_mode: bool,
     ) -> Self {
         let accent = parse_color(accent_color_str);
         let mention = mention_color_str.map(parse_color);
         let selection = selection_color_str.map(parse_color);
+        let base = base_color_str.map(parse_color);
 
         if is_light_mode {
-            Self::from_palette(&LightPalette, accent, mention, selection)
+            Self::from_palette(&LightPalette, accent, mention, selection, base)
         } else {
-            Self::from_palette(&DarkPalette, accent, mention, selection)
+            Self::from_palette(&DarkPalette, accent, mention, selection, base)
         }
     }
 
@@ -52,12 +54,13 @@ impl Theme {
         accent: Color,
         mention_color: Option<Color>,
         selection_color: Option<Color>,
+        base_color: Option<Color>,
     ) -> Self {
         let mention_base = mention_color.unwrap_or(Color::Blue);
 
         Self {
             keybind_style: palette.keybind_style(accent),
-            keybind_description_style: palette.keybind_description_style(),
+            keybind_description_style: palette.keybind_description_style(base_color),
             title_style: palette.title_style(accent),
             tab_style: palette.tab_style(),
             tab_selected_style: palette.tab_selected_style(),
@@ -66,7 +69,7 @@ impl Theme {
             mention_style: palette.mention_style(mention_base),
             selection_style: palette.selection_style(accent, selection_color),
             dimmed_style: palette.dimmed_style(),
-            base_style: palette.base_style(),
+            base_style: palette.base_style(base_color),
             error_style: palette.error_style(),
             warning_style: palette.warning_style(),
             success_style: palette.success_style(),
@@ -81,8 +84,9 @@ impl Theme {
         accent: Color,
         mention_color: Option<Color>,
         selection_color: Option<Color>,
+        base_color: Option<Color>,
     ) -> Self {
-        Self::from_palette(&DarkPalette, accent, mention_color, selection_color)
+        Self::from_palette(&DarkPalette, accent, mention_color, selection_color, base_color)
     }
 }
 

--- a/src/presentation/ui/app.rs
+++ b/src/presentation/ui/app.rs
@@ -2358,7 +2358,7 @@ mod tests {
         let auth = Arc::new(MockAuthPort::new(true));
         let data = Arc::new(MockDiscordData);
         let storage = Arc::new(MockTokenStorage::new());
-        let theme = Theme::new("Orange", None, false);
+        let theme = Theme::new("Orange", None, None, false);
         let identity = Arc::new(ClientIdentity::new());
         let config = AppConfig {
             disable_user_colors: false,

--- a/src/presentation/ui/app.rs
+++ b/src/presentation/ui/app.rs
@@ -2358,7 +2358,7 @@ mod tests {
         let auth = Arc::new(MockAuthPort::new(true));
         let data = Arc::new(MockDiscordData);
         let storage = Arc::new(MockTokenStorage::new());
-        let theme = Theme::new("Orange", None, None, false);
+        let theme = Theme::new("Orange", None, None, None, false);
         let identity = Arc::new(ClientIdentity::new());
         let config = AppConfig {
             disable_user_colors: false,

--- a/src/presentation/ui/chat_screen.rs
+++ b/src/presentation/ui/chat_screen.rs
@@ -3141,7 +3141,7 @@ mod tests {
             true,
             true,
             "%H:%M".to_string(),
-            Theme::new("Orange", None, false),
+            Theme::new("Orange", None, None, false),
             true,
             CommandRegistry::default(),
             RelationshipState::new(),

--- a/src/presentation/ui/chat_screen.rs
+++ b/src/presentation/ui/chat_screen.rs
@@ -33,7 +33,7 @@ use crate::presentation::widgets::{
     ForumState, GuildsTree, GuildsTreeAction, GuildsTreeData, GuildsTreeState, HeaderBar,
     ImageManager, MentionPopup, MessageInput, MessageInputAction, MessageInputMode,
     MessageInputState, MessagePane, MessagePaneAction, MessagePaneData, MessagePaneState,
-    TreeNodeId, ViewMode,
+    MessagePaneStyle, TreeNodeId, ViewMode,
 };
 use ratatui::{
     buffer::Buffer,
@@ -548,17 +548,14 @@ fn render_message_pane(state: &mut ChatScreenState, area: Rect, buf: &mut Buffer
     let hide_blocked_completely = state.hide_blocked_completely;
 
     let inner_width = area.width.saturating_sub(2);
+    let style = MessagePaneStyle::from_theme(&state.theme);
     state.message_pane_data.update_layout(
         inner_width,
         &service,
-        state.theme.accent,
+        style.content_style,
         state.message_pane_state.show_spoilers,
         image_preview,
     );
-
-    state.update_visible_image_protocols(inner_width);
-
-    let style = MessagePaneStyle::from_theme(&state.theme);
     let current_user_id = state.user().id().to_string();
     let (data, pane_state) = state.message_pane_parts_mut();
 
@@ -2032,10 +2029,11 @@ impl ChatScreenState {
             .with_image_preview(self.image_preview)
             .with_timestamp_format(&self.timestamp_format)
             .with_current_user_id(self.user.id().to_string());
+        let style = MessagePaneStyle::from_theme(&self.theme);
         let added_height: u16 = new_messages
             .iter()
             .map(|m| {
-                pane.calculate_message_height(m, width, &self.markdown_service, self.theme.accent)
+                pane.calculate_message_height(m, width, &self.markdown_service, style.content_style)
             })
             .sum();
 

--- a/src/presentation/ui/chat_screen.rs
+++ b/src/presentation/ui/chat_screen.rs
@@ -3141,7 +3141,7 @@ mod tests {
             true,
             true,
             "%H:%M".to_string(),
-            Theme::new("Orange", None, None, false),
+            Theme::new("Orange", None, None, None, false),
             true,
             CommandRegistry::default(),
             RelationshipState::new(),

--- a/src/presentation/widgets/header_bar.rs
+++ b/src/presentation/widgets/header_bar.rs
@@ -47,10 +47,7 @@ impl HeaderBarStyle {
     #[must_use]
     pub fn from_theme(theme: &Theme) -> Self {
         Self {
-            app_name: Style::default()
-                .bg(theme.accent)
-                .fg(Color::Black)
-                .add_modifier(Modifier::BOLD),
+            app_name: theme.title_style,
             version: theme.dimmed_style,
             status_connected: theme.success_style.add_modifier(Modifier::BOLD),
             status_disconnected: theme.error_style.add_modifier(Modifier::BOLD),

--- a/src/presentation/widgets/message_pane.rs
+++ b/src/presentation/widgets/message_pane.rs
@@ -171,7 +171,7 @@ fn calculate_embed_layout(
     embed: &Embed,
     width: u16,
     markdown_service: &MarkdownRenderer,
-    default_color: Color,
+    content_style: Style,
 ) -> RenderedEmbed {
     let mut height = 0;
     let width = width.saturating_sub(2);
@@ -195,7 +195,7 @@ fn calculate_embed_layout(
     }
 
     if let Some(description) = &embed.description {
-        let text = markdown_service.render_markdown(description, None, false);
+        let text = markdown_service.render_markdown(description, None, false, content_style);
 
         let wrapped_text = wrap_styled_text(text, width);
         let content_lines = u16::try_from(wrapped_text.lines.len()).unwrap_or(0);
@@ -216,7 +216,7 @@ fn calculate_embed_layout(
             u8::try_from(c & 0xFF).unwrap_or(0),
         )
     } else {
-        default_color
+        content_style.fg.unwrap_or(Color::Reset)
     };
 
     RenderedEmbed {
@@ -603,7 +603,7 @@ impl MessagePaneData {
         &mut self,
         width: u16,
         markdown_service: &MarkdownRenderer,
-        default_color: Color,
+        content_style: Style,
         show_spoilers: bool,
         image_preview: bool,
     ) {
@@ -644,7 +644,7 @@ impl MessagePaneData {
                 ui_msg,
                 content_width,
                 markdown_service,
-                default_color,
+                content_style,
                 show_spoilers,
                 image_preview,
                 &resolver,
@@ -666,7 +666,7 @@ impl MessagePaneData {
         ui_msg: &mut UiMessage,
         content_width: u16,
         markdown_service: &MarkdownRenderer,
-        default_color: Color,
+        content_style: Style,
         show_spoilers: bool,
         image_preview: bool,
         resolver: &HashMapResolver<'_>,
@@ -677,7 +677,12 @@ impl MessagePaneData {
         let message = &ui_msg.message;
 
         let text =
-            markdown_service.render(ui_msg.parsed_content.clone(), Some(resolver), show_spoilers);
+            markdown_service.render(
+                ui_msg.parsed_content.clone(),
+                Some(resolver),
+                show_spoilers,
+                content_style,
+            );
 
         let wrapped_text = wrap_styled_text(text, content_width);
         let content_lines = u16::try_from(wrapped_text.lines.len()).unwrap_or(0);
@@ -710,7 +715,7 @@ impl MessagePaneData {
         let mut rendered_embeds = Vec::new();
         for embed in message.embeds() {
             let layout =
-                calculate_embed_layout(embed, content_width, markdown_service, default_color);
+                calculate_embed_layout(embed, content_width, markdown_service, content_style);
             height += layout.height;
             rendered_embeds.push(layout);
         }
@@ -1338,9 +1343,11 @@ impl MessagePaneStyle {
             title_style: Style::default()
                 .fg(theme.accent)
                 .add_modifier(Modifier::BOLD),
+            topic_style: theme.dimmed_style,
             author_style: Style::default()
                 .fg(theme.accent)
                 .add_modifier(Modifier::BOLD),
+            content_style: theme.base_style,
             selected_style: theme.selection_style,
             mention_style: theme.mention_style,
             reply_style: theme.dimmed_style.add_modifier(Modifier::ITALIC),
@@ -1478,7 +1485,7 @@ impl<'a> MessagePane<'a> {
         message: &Message,
         width: u16,
         markdown_service: &MarkdownRenderer,
-        default_color: Color,
+        content_style: Style,
     ) -> u16 {
         let indent_width = u16::try_from(CONTENT_INDENT).unwrap_or(0);
         let content_width = width
@@ -1488,7 +1495,7 @@ impl<'a> MessagePane<'a> {
         let authors = &self.data.authors;
         let channels = &self.data.channels;
         let resolver = HashMapResolver { authors, channels };
-        let text = markdown_service.render_markdown(message.content(), Some(&resolver), false);
+        let text = markdown_service.render_markdown(message.content(), Some(&resolver), false, content_style);
 
         let mut content_lines = 0;
         for line in &text.lines {
@@ -1528,7 +1535,7 @@ impl<'a> MessagePane<'a> {
         }
 
         for embed in message.embeds() {
-            height += calculate_embed_layout(embed, content_width, markdown_service, default_color)
+            height += calculate_embed_layout(embed, content_width, markdown_service, content_style)
                 .height;
         }
 
@@ -1622,11 +1629,13 @@ impl<'a> MessagePane<'a> {
             return;
         }
 
+        let show_spoilers = state.show_spoilers;
+
         data.update_layout(
-            inner_area.width,
+            area.width,
             markdown_service,
-            style.content_style.fg.unwrap_or(Color::White),
-            state.show_spoilers,
+            style.content_style,
+            show_spoilers,
             *image_preview,
         );
 
@@ -2840,7 +2849,7 @@ mod tests {
         data.set_messages(messages);
 
         let markdown = MarkdownRenderer::new();
-        data.update_layout(100, &markdown, Color::Yellow, false, true);
+        data.update_layout(100, &markdown, Style::default(), false, true);
 
         let mut state = MessagePaneState::new();
         state.flags.is_following = true;
@@ -2976,7 +2985,7 @@ mod tests {
 
         let message = create_test_message(1, "Content").with_embeds(vec![embed]);
 
-        let height = pane.calculate_message_height(&message, 100, &markdown, Color::Yellow);
+        let height = pane.calculate_message_height(&message, 100, &markdown, Style::default());
         assert_eq!(height, 6, "Height should be 6 with padding changes");
     }
 


### PR DESCRIPTION
This Pull Request introduces three enhancements to the theming engine to allow for better terminal theme matching and customization:

1. **Selection Color Configuration**: Adds `selection_color` to the `[theme]` section of `config.toml`, allowing users to override the hardcoded highlight background.
2. **Base Text Color Configuration**: Adds `base_color` to the `[theme]` section, allowing users to force a specific color (like pure White) for normal text instead of relying on terminal defaults.
3. **Transparency Support**: Adds a `transparent` keyword to the color parser (mapping to `Color::Reset`), enabling "no-background" highlights if desired.

These changes were implemented to address feedback regarding hover/highlight colors not always matching custom terminal themes (specifically high-contrast or transparent setups).