### PR TITLE
fix: add missing header_text_color_str argument to Theme::new call sites

### DIFF
--- a/src/presentation/ui/app.rs
+++ b/src/presentation/ui/app.rs
@@ -2358,7 +2358,7 @@ mod tests {
         let auth = Arc::new(MockAuthPort::new(true));
         let data = Arc::new(MockDiscordData);
         let storage = Arc::new(MockTokenStorage::new());
-        let theme = Theme::new("Orange", None, None, None, false);
+        let theme = Theme::new("Orange", None, None, None, None, false);
         let identity = Arc::new(ClientIdentity::new());
         let config = AppConfig {
             disable_user_colors: false,

--- a/src/presentation/ui/chat_screen.rs
+++ b/src/presentation/ui/chat_screen.rs
@@ -3139,7 +3139,7 @@ mod tests {
             true,
             true,
             "%H:%M".to_string(),
-            Theme::new("Orange", None, None, None, false),
+            Theme::new("Orange", None, None, None, None, false),
             true,
             CommandRegistry::default(),
             RelationshipState::new(),


### PR DESCRIPTION
## Summary

- `Theme::new` was updated to accept a 6th parameter (`header_text_color_str: Option<&str>`) but two call sites were not updated, causing a build failure
- Both call sites are in test/mock contexts (`app.rs` and `chat_screen.rs`) — added `None` for the new parameter

## The error

```
error[E0061]: this function takes 6 arguments but 5 arguments were supplied
    --> src/presentation/ui/chat_screen.rs:3142:13
     |
3142 |             Theme::new("Orange", None, None, None, false),
     |             ^^^^^^^^^^                             ----- argument #5 of type `Option<&str>` is missing
```

Same error in `src/presentation/ui/app.rs:2361`.

## Test plan

- [x] `cargo check` passes